### PR TITLE
スタッフ欄の余白調整

### DIFF
--- a/_sass/_profile.scss
+++ b/_sass/_profile.scss
@@ -7,10 +7,6 @@
     margin-bottom: 2%;
     text-align: center;
 
-    @media screen and (min-width: 676px) {
-        max-height: 130px;
-    }
-
     img {
         display: inline-block;
         border-radius: 50%;


### PR DESCRIPTION
スタッフ欄が2段以上になったときに上下で被ってしまう現象が発生していたので修正します。

`organizer-profile` クラスの `max-height` が 130px になっているせいで、その配下にある `organizer-info` の height が大きいと `organizer-profile` の箱を飛び越えてしまうというのが原因でした。  
消しても特に問題なさそうなので、`max-height` 属性を削除します。

### before
<img width="779" alt="スクリーンショット 2024-02-27 13 44 17" src="https://github.com/nlp-colloquium-jp/nlp-colloquium-jp.github.io/assets/18324061/3fce1c6b-ee47-4871-88ab-25257d19b7de">

### after
<img width="789" alt="スクリーンショット 2024-02-27 13 44 29" src="https://github.com/nlp-colloquium-jp/nlp-colloquium-jp.github.io/assets/18324061/605e2ada-c833-41a3-b6cf-3326294e8f29">



