### PR TITLE
スケジュールを JSON 形式で得られる API を追加

### DIFF
--- a/api/schedules.json
+++ b/api/schedules.json
@@ -1,0 +1,20 @@
+---
+layout: none
+---
+[{% for item in site.schedule reversed %}{% if item.display %}
+  {
+    "number": {{ forloop.rindex }},
+    "name": {{ item.name | jsonify }},
+    "name_en": {{ item.name_en | jsonify }},
+    "affiliation": {{ item.affiliation | jsonify }},
+    "website": {{ item.website | jsonify }},
+    "topic": {{ item.topic | jsonify }},
+    "abstract": {{ item.abstract | jsonify }},
+    "date": {{ item.date | jsonify }},
+    "time_end": {{ item.time_end | jsonify }},
+    "bio": {{ item.bio | jsonify }},
+    "talk_url": {{ item.url | absolute_url | jsonify }},
+    "id": {{ item.id | jsonify }},
+    "md_path": {{ item.path | jsonify }}
+  }{% unless forloop.last %},{% endunless %}{% endif %}{% endfor -%}
+]


### PR DESCRIPTION
`/api/schedules.json` にアクセスするとこんな感じ↓のスケジュール一覧 json を返してくれるようになるはずです。  
諸々の自動化において（いつかは……）活用される予定です  
ローカル環境では動きましたが、github-pages が `/api/` 配下のレンダリングをちゃんとやってくれるかは知らないので、とりあえずマージして試しちゃいます。
  
```json
[
  {
    "number": 60,
    "name": "磯沼大",
    "name_en": "Masaru Isonuma",
    "affiliation": "University of Edinburgh",
    "website": "https://www.isonuma.com/",
    "topic": "TBD",
    "abstract": "TBD",
    "date": "2024-07-03 18:00:00 +0900",
    "time_end": null,
    "bio": "TBD",
    "talk_url": "http://localhost:4000/schedule/2024-07-03_masaru-isonuma/",
    "id": "/schedule/2024-07-03_masaru-isonuma",
    "md_path": "_schedule/2024-07-03_masaru-isonuma.md"
  },
...
]
```

