### PR TITLE
[hotfix] 次回予告欄のタイムゾーン名と時刻表示が一貫していないバグを修正

### DIFF
--- a/assets/js/next_talk.js
+++ b/assets/js/next_talk.js
@@ -67,8 +67,7 @@ async function displayClosestTalk() {
             minute: "numeric"
         }).format(end_date);
         const tz = new Intl.DateTimeFormat("ja-JP", {
-            timeZoneName: "short",
-            timeZone: closestTalk.timezone
+            timeZoneName: "shortGeneric"
         }).formatToParts(date).find(part => part.type === 'timeZoneName').value;
         console.log(date_str);
         const name = prepareNameColumn(closestTalk.name, closestTalk.name_en, closestTalk.website)
@@ -76,7 +75,7 @@ async function displayClosestTalk() {
         if (checkIfOngoing(closestTalk)) {
             nextTalkDiv.classList.add("bd-callout", "bd-callout-themecolor");
             nextTalkDiv.innerHTML = `
-            <p>現在下記のトークを開催中です！${date_str} ~ ${end_date_str} ${tz}</p>
+            <p>現在下記のトークを開催中です！${date_str} ~ ${end_date_str} (${tz})</p>
             <dl class="row mb-1" style="margin-bottom: 0px;">
                 <dt class="col-sm-2 mb-1">スピーカー</dt>
                 <dd class="col-sm-10 mb-1">${name}</dd>
@@ -86,7 +85,7 @@ async function displayClosestTalk() {
         } else {
             nextTalkDiv.classList.add("bd-callout", "bd-callout-default");
             nextTalkDiv.innerHTML = `
-            <p>次回のトークは ${date_str} ${tz} より開始予定です。</p>
+            <p>次回のトークは ${date_str} (${tz}) より開始予定です。</p>
             <dl class="row mb-1" style="margin-bottom: 0px;">
                 <dt class="col-sm-2 mb-1">スピーカー</dt>
                 <dd class="col-sm-10 mb-1">${name}</dd>


### PR DESCRIPTION
次回予告欄の時刻表示が、タイムゾーンを「JST」と表示しておきながら時刻は現地時間という状態になっていました。  
現地時間を表示する仕様を正として、タイムゾーンも現地のものを表示するように修正します。

## 動作確認
ロケールを "ja-JP" にしている都合上、日本（JST）以外のタイムゾーン表記が我々的にしっくりこない形式になってしまっていますが、まあ分かるのでヨシということで……
![image](https://github.com/user-attachments/assets/be475626-d731-4d97-baf7-bad6c6b03236)
![image](https://github.com/user-attachments/assets/5d3bc7b8-722e-41af-a3de-601cd4b6c628)
![image](https://github.com/user-attachments/assets/fe466174-f0a7-4d88-a1eb-d92895f4210c)
