### PR TITLE
スケジュール表を折りたたんで表示するように修正し、展開機能を実装する

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,6 +22,8 @@ impressum_path:  # set to path to include impressum link in the footer, use the 
 
 timezone: Asia/Tokyo
 
+initial_visible_rows: 10
+
 # -----------------------------------------------------------------------------
 # Theme
 # -----------------------------------------------------------------------------

--- a/_config.yml
+++ b/_config.yml
@@ -22,6 +22,7 @@ impressum_path:  # set to path to include impressum link in the footer, use the 
 
 timezone: Asia/Tokyo
 
+enable_folding_table: true
 initial_visible_rows: 10
 
 # -----------------------------------------------------------------------------

--- a/_includes/schedule.html
+++ b/_includes/schedule.html
@@ -8,7 +8,7 @@
       </thead>
       <tbody>
         {% for item in site.schedule reversed %}
-          {% if forloop.index > site.initial_visible_rows %}
+          {% if site.enable_folding_table and (forloop.index > site.initial_visible_rows) %}
             {% assign row_class = "hidden-row" %}
           {% else %}
             {% assign row_class = "visible-row" %}
@@ -71,14 +71,18 @@
             </tr>
           {% endif %}
         {% endfor %}
+        {% if site.enable_folding_table and (site.schedule.size > site.initial_visible_rows) %}
         <tr class="expand-button-row" style="display: none;">
           <td colspan="4" align="center">
             <button class="btn btn-outline-danger" id="show-more-btn" role="button">すべて表示</a>
           </td>
         </tr>
+        {% endif %}
       </tbody>
     </table>
     
-    <script src="{{ '/assets/js/fold_table.js' | relative_url }}"></script>
+    {% if site.enable_folding_table %}
+      <script src="{{ '/assets/js/fold_table.js' | relative_url }}"></script>
+    {% endif %}
   </div>
 </div>

--- a/_includes/schedule.html
+++ b/_includes/schedule.html
@@ -8,8 +8,13 @@
       </thead>
       <tbody>
         {% for item in site.schedule reversed %}
+          {% if forloop.index > site.initial_visible_rows %}
+            {% assign row_class = "hidden-row" %}
+          {% else %}
+            {% assign row_class = "visible-row" %}
+          {% endif %}
           {% if item.display %}
-            <tr>
+            <tr class="{{ row_class }}">
               <th scope="row" style="text-align: right;">
                 {{ forloop.rindex }}
               </th>
@@ -66,7 +71,14 @@
             </tr>
           {% endif %}
         {% endfor %}
+        <tr class="expand-button-row" style="display: none;">
+          <td colspan="4" align="center">
+            <button class="btn btn-outline-danger" id="show-more-btn" role="button">すべて表示</a>
+          </td>
+        </tr>
       </tbody>
     </table>
+    
+    <script src="{{ '/assets/js/fold_table.js' | relative_url }}"></script>
   </div>
 </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,6 +3,7 @@
 
   <!-- Head -->
   <head>
+  {% include scripts/jquery.html %}
   {%- if page.redirect -%}
     <meta http-equiv="refresh" content="3; url={{ site.baseurl | prepend: site.url }}/" />
   {%- endif -%}
@@ -24,7 +25,6 @@
     {%- include footer.html %}
 
     <!-- JavaScripts -->
-    {% include scripts/jquery.html %}
     {% include scripts/bootstrap.html %}
     {% include scripts/masonry.html %}
     {% include scripts/misc.html %}

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -87,6 +87,16 @@ a.btn-outline-danger:hover {
   border-color: var(--global-theme-color) !important;
 }
 
+button.btn-outline-danger {
+  color: var(--global-theme-color) !important;
+  border-color: var(--global-theme-color) !important;
+}
+
+button.btn-outline-danger:hover {
+  color: var(--global-theme-color) !important;
+  border-color: var(--global-theme-color) !important;
+}
+
 strong {
   font-weight: 700;
 }

--- a/assets/js/fold_table.js
+++ b/assets/js/fold_table.js
@@ -1,10 +1,25 @@
 $(document).ready(function(){
-    $(".hidden-row").hide();
-    $(".expand-button-row").show();
+    const entries = window.performance.getEntriesByType('navigation')
+    var isBrowserBackUsed = false;
+    var isExpandedPrev = sessionStorage.getItem('isExpanded');
+
+    for (const entry of entries) {
+        if (entry.type === 'back_forward' | entry.type === 'reload') {
+            isBrowserBackUsed = true;
+        }
+    }
+
+    if (!isBrowserBackUsed | !isExpandedPrev) {
+        console.log("!");
+        $(".hidden-row").hide();
+        $(".expand-button-row").show();
+        sessionStorage.setItem('isExpanded', false);
+    };
 
     $("#show-more-btn").click(function(){
         $(".hidden-row").show();
         $(this).hide();
         $(".expand-button-row").hide();
+        sessionStorage.setItem('isExpanded', true);
     });
 });

--- a/assets/js/fold_table.js
+++ b/assets/js/fold_table.js
@@ -1,0 +1,10 @@
+$(document).ready(function(){
+    $(".hidden-row").hide();
+    $(".expand-button-row").show();
+
+    $("#show-more-btn").click(function(){
+        $(".hidden-row").show();
+        $(this).hide();
+        $(".expand-button-row").hide();
+    });
+});

--- a/assets/js/fold_table.js
+++ b/assets/js/fold_table.js
@@ -1,25 +1,31 @@
 $(document).ready(function(){
+    function toBoolean(booleanStr) {
+        if (booleanStr === null) {
+            return false
+        }
+        return booleanStr.toLowerCase() === "true";
+    }
+
     const entries = window.performance.getEntriesByType('navigation')
     var isBrowserBackUsed = false;
-    var isExpandedPrev = sessionStorage.getItem('isExpanded');
+    var isExpandedPrev = toBoolean(sessionStorage.getItem('isExpanded'));
 
     for (const entry of entries) {
-        if (entry.type === 'back_forward' | entry.type === 'reload') {
+        if (["back_forward", "reload"].includes(entry.type)) {
             isBrowserBackUsed = true;
         }
     }
 
-    if (!isBrowserBackUsed | !isExpandedPrev) {
-        console.log("!");
+    if (!isBrowserBackUsed || !isExpandedPrev) {
         $(".hidden-row").hide();
         $(".expand-button-row").show();
-        sessionStorage.setItem('isExpanded', false);
+        sessionStorage.setItem('isExpanded', 'false');
     };
 
     $("#show-more-btn").click(function(){
         $(".hidden-row").show();
         $(this).hide();
         $(".expand-button-row").hide();
-        sessionStorage.setItem('isExpanded', true);
+        sessionStorage.setItem('isExpanded', 'true');
     });
 });


### PR DESCRIPTION
こんな感じ↓で、スケジュール表が初期状態（外部リンク/お気に入りなどからアクセスした状態）では折り畳まれた状態になります。
「すべて表示」ボタンを押すとすべて表示されます。
![画面収録 2024-10-25 16 38 46_480](https://github.com/user-attachments/assets/91daf7ac-8444-434b-813b-1a2949aabf35)
細かい仕様として、リンクをクリックしてどこかに飛んだあとにブラウザバックで戻ってくると、展開/折りたたみ状態が維持されたまま表示されます。
（再読み込みの場合も同様。次回アクセス時には折りたたみ状態に戻る）

_config.yml の `initial_visible_rows` パラメータをいじれば初期状態で表示される行数を変更できます。とりあえず10行にしてます。
また、 `enable_folding_table` を `false` にすれば折りたたみ機能が無効化されます。