### PR TITLE
「すべて表示」ボタンの表示に時間がかかるバグの修正

### DIFF
--- a/_includes/schedule.html
+++ b/_includes/schedule.html
@@ -2,21 +2,6 @@
   <h1>スケジュール</h1>
   月に1-2回、日本時間水曜正午より開催します。<br>
   <div class="table-responsive">
-    {% if site.enable_folding_table %}
-      <script src="{{ '/assets/js/fold_table.js' | relative_url }}" defer></script>
-      <style>
-        .hidden-row {
-          display: none;
-        }
-      </style>
-      <noscript>
-        <style>
-          .hidden-row {
-            display: table-row !important;
-          }
-        </style>
-      </noscript>
-    {% endif %}
     <table id="scheduleTable" class="table table-sm table-borderless">
       <thead>
         <tr><th style="width: 5%; text-align: right;">#</th><th style="width: 20%;">日時</th><th style="width: 30%;">スピーカー</th><th style="width: 45%;">トピック</th></tr>
@@ -95,5 +80,8 @@
         {% endif %}
       </tbody>
     </table>
+    {% if site.enable_folding_table %}
+      <script src="{{ '/assets/js/fold_table.js' | relative_url }}" async></script>
+    {% endif %}
   </div>
 </div>

--- a/_includes/schedule.html
+++ b/_includes/schedule.html
@@ -2,6 +2,21 @@
   <h1>スケジュール</h1>
   月に1-2回、日本時間水曜正午より開催します。<br>
   <div class="table-responsive">
+    {% if site.enable_folding_table %}
+      <script src="{{ '/assets/js/fold_table.js' | relative_url }}" defer></script>
+      <style>
+        .hidden-row {
+          display: none;
+        }
+      </style>
+      <noscript>
+        <style>
+          .hidden-row {
+            display: table-row !important;
+          }
+        </style>
+      </noscript>
+    {% endif %}
     <table id="scheduleTable" class="table table-sm table-borderless">
       <thead>
         <tr><th style="width: 5%; text-align: right;">#</th><th style="width: 20%;">日時</th><th style="width: 30%;">スピーカー</th><th style="width: 45%;">トピック</th></tr>
@@ -80,9 +95,5 @@
         {% endif %}
       </tbody>
     </table>
-    
-    {% if site.enable_folding_table %}
-      <script src="{{ '/assets/js/fold_table.js' | relative_url }}"></script>
-    {% endif %}
   </div>
 </div>

--- a/_pages/top.md
+++ b/_pages/top.md
@@ -16,7 +16,7 @@ social: false  # includes social icons at the bottom of the page
 
 
 <div id="next-talk"></div>
-<script src="{{ '/assets/js/next_talk.js' | relative_url }}"></script>
+<script src="{{ '/assets/js/next_talk.js' | relative_url }}" async></script>
 
 
 # 参加方法

--- a/assets/js/fold_table.js
+++ b/assets/js/fold_table.js
@@ -16,10 +16,7 @@
         }
     }
 
-    if (isBrowserBackUsed && isExpandedPrev) {
-        $(".hidden-row").show();
-        $(".expand-button-row").hide();
-    } else {
+    if (!isBrowserBackUsed || !isExpandedPrev) {
         $(".hidden-row").hide();
         $(".expand-button-row").show();
         sessionStorage.setItem('isExpanded', 'false');

--- a/assets/js/fold_table.js
+++ b/assets/js/fold_table.js
@@ -1,4 +1,4 @@
-$(document).ready(function(){
+(function(){
     function toBoolean(booleanStr) {
         if (booleanStr === null) {
             return false
@@ -31,4 +31,4 @@ $(document).ready(function(){
         $(".expand-button-row").hide();
         sessionStorage.setItem('isExpanded', 'true');
     });
-});
+})();

--- a/assets/js/fold_table.js
+++ b/assets/js/fold_table.js
@@ -16,7 +16,10 @@ $(document).ready(function(){
         }
     }
 
-    if (!isBrowserBackUsed || !isExpandedPrev) {
+    if (isBrowserBackUsed && isExpandedPrev) {
+        $(".hidden-row").show();
+        $(".expand-button-row").hide();
+    } else {
         $(".hidden-row").hide();
         $(".expand-button-row").show();
         sessionStorage.setItem('isExpanded', 'false');


### PR DESCRIPTION
環境によっては「すべて表示」ボタンが表示されるまでに時間がかかる場合がある https://github.com/nlp-colloquium-jp/nlp-colloquium-jp.github.io/issues/25

~~この解決のために色々と策を施します。~~
~~1. fold_table.js を `<table>` タグより前の時点で `defer` モードで読み込むように変更することで、少しでも読み込み時間を早める（`defer` だと html レンダリング中に並列で js を読み込んでくれて、実行だけは最後にやってくれます。）
2. js が読み込まれる前から（css 側で）デフォルトで11行目以降を隠しておく。
3. 念の為 js 非対応の環境では11行目以降が隠されないように `<noscript>` で対応~~

この解決のために、`fold_table.js` の実行タイミングについて、DOM の読み込みを待たないように修正します。
（触りたいのは table タグの中身だけなので、元々最後まで待つ必要がなかった）

DOM の読み込みに（環境によって）時間がかかる根本原因自体はよく分かっていません。怪しいのは mathjax？