### PR TITLE
notice要素を次回トーク告知欄に表示する機能を追加

### DIFF
--- a/_schedule/2025-11-19_taku_kudo.md
+++ b/_schedule/2025-11-19_taku_kudo.md
@@ -15,6 +15,7 @@ abstract: |-
   SentencePieceは、LLMを含む多くのニューラルNLPモデルに採用されており、トークン化のパラダイムを大きく変えました。  
   本発表では、MeCabの開発者が、なぜ伝統的な辞書・文法ベースの日本語特化型トークナイではなく、それらとは対局にある言語非依存・多言語トークナイザ SentencePiece を開発したのか、その歴史的背景と経緯について紹介します。
 display: true
+notice: "今回はYouTube動画の公開はありません。ぜひリアルタイムでご参加ください。"
 ---
 
 [[GitHubリポジトリ]](https://github.com/google/sentencepiece) [[論文1]](https://aclanthology.org/D18-2012/) (EMNLP 2018) [[論文2]](https://arxiv.org/abs/1804.10959) (ACL 2018)

--- a/api/schedule.json
+++ b/api/schedule.json
@@ -29,7 +29,8 @@ layout: none
       "bio": {{ item.bio | jsonify }},
       "talk_url": {{ item.url | absolute_url | jsonify }},
       "id": {{ item.id | jsonify }},
-      "md_path": {{ item.path | jsonify }}
+      "md_path": {{ item.path | jsonify }},
+      "notice": {{ item.notice | jsonify }}
     }{% unless forloop.last %},{% endunless %}{% endif %}{% endfor -%}
   ]
 }

--- a/assets/js/next_talk.js
+++ b/assets/js/next_talk.js
@@ -71,7 +71,8 @@ async function displayClosestTalk() {
         }).formatToParts(date).find(part => part.type === 'timeZoneName').value;
         console.log(date_str);
         const name = prepareNameColumn(closestTalk.name, closestTalk.name_en, closestTalk.website)
-
+        // If there's a notice field, render it in bold below the details
+        const notice_html = closestTalk.notice ? `<p style="text-align:center;font-weight:700"><strong>${closestTalk.notice}</strong></p>` : '';
         if (checkIfOngoing(closestTalk)) {
             nextTalkDiv.classList.add("bd-callout", "bd-callout-themecolor");
             nextTalkDiv.innerHTML = `
@@ -81,7 +82,9 @@ async function displayClosestTalk() {
                 <dd class="col-sm-10 mb-1">${name}</dd>
                 <dt class="col-sm-2 mb-1">トピック</dt>
                 <dd class="col-sm-10 mb-1"><a href=${closestTalk.talk_url}>${closestTalk.topic}</a></dd>
-            </dl>`;
+            </dl>
+            ${notice_html}`;
+                
         } else {
             nextTalkDiv.classList.add("bd-callout", "bd-callout-default");
             nextTalkDiv.innerHTML = `
@@ -91,7 +94,8 @@ async function displayClosestTalk() {
                 <dd class="col-sm-10 mb-1">${name}</dd>
                 <dt class="col-sm-2 mb-1">トピック</dt>
                 <dd class="col-sm-10 mb-1"><a href=${closestTalk.talk_url}>${closestTalk.topic}</a></dd>
-            </dl>`;
+            </dl>
+            ${notice_html}`;
         }
     } else {
         nextTalkDiv.innerHTML = '';


### PR DESCRIPTION
次回のトークに関してお知らせがある場合に表示する機能です。`_schedule`にある各トークのマークダウンに "notice" 要素（自由記述のテキスト）を追加すると、トップページに表示されます。

見た目やレイアウトなど自由に編集してください。

<img width="805" height="202" alt="next-talk-notice" src="https://github.com/user-attachments/assets/f4924d1f-3bc1-49d6-a18d-aa773194e7d3" />
